### PR TITLE
Fix misleading branch name example in placeholder text

### DIFF
--- a/kafkistry-web/src/main/resources/ui/common/updateForm.ftl
+++ b/kafkistry-web/src/main/resources/ui/common/updateForm.ftl
@@ -17,7 +17,7 @@
         <#if gitStorageEnabled>
             <label class="col-6">
                 Choose branch to write into:
-                <#assign branchPlaceholder = gitBranchRequiredJiraKey?then((gitMainBranch) + ' or branch with JIRA key (e.g., ABC-123-feature)', 'custom branch name or (empty) for default')>
+                <#assign branchPlaceholder = gitBranchRequiredJiraKey?then((gitMainBranch) + ' or branch with JIRA key (e.g., ABC-123 or feature/ABC-123)', 'custom branch name or (empty) for default')>
                 <input class="form-control" name="targetBranch"
                        placeholder="${branchPlaceholder}"
                        value="${branch!''}">


### PR DESCRIPTION
The placeholder showed "ABC-123-feature" as a valid example, but the JIRA_REGEX only allows "/" as a practical separator for branch names. Users were confused when their hyphen-separated branches were rejected despite following the suggested format.