### PR TITLE
Gvinicki remove detached acls

### DIFF
--- a/kafkistry-app/src/test/kotlin/com/infobip/kafkistry/manual.kt
+++ b/kafkistry-app/src/test/kotlin/com/infobip/kafkistry/manual.kt
@@ -597,6 +597,23 @@ class DataStateInitializer(
                     log.info("Adding principal ACLs: {}", it)
                 }
             )
+            api.createPrincipalAcls(
+                PrincipalAclRules(
+                    principal = "User:detached-demo",
+                    description = "Principal with a detached ACL rule referencing a deleted topic",
+                    owner = "test-owner",
+                    rules = listOf(
+                        "User:detached-demo * TOPIC:topic-example-1 READ ALLOW".parseAcl()
+                            .toAclRule(Presence(PresenceType.ALL_CLUSTERS)),
+                        "User:detached-demo * TOPIC:topic-deleted-xyz WRITE ALLOW".parseAcl()
+                            .toAclRule(Presence(PresenceType.ALL_CLUSTERS)),
+                        "User:detached-demo * GROUP:detached-group READ ALLOW".parseAcl()
+                            .toAclRule(Presence(PresenceType.ALL_CLUSTERS)),
+                    )
+                ).also {
+                    log.info("Adding principal ACLs: {}", it)
+                }
+            )
         } catch (ex: Exception) {
             log.error("Exception while creating principal acls, ignoring...", ex)
         }
@@ -606,6 +623,9 @@ class DataStateInitializer(
                 "User:bob * GROUP:group* READ ALLOW".parseAcl(),
                 "User:alice * TOPIC:topic-example-1 ALL ALLOW".parseAcl(),
                 "User:mark * TOPIC:topic-example-3 ALL ALLOW".parseAcl(),
+                "User:detached-demo * TOPIC:topic-example-1 READ ALLOW".parseAcl(),
+                "User:detached-demo * TOPIC:topic-deleted-xyz WRITE ALLOW".parseAcl(),
+                "User:detached-demo * GROUP:detached-group READ ALLOW".parseAcl(),
             )
             log.info("Creating ACLs on kafka: {}", acls)
             it.createAcls(acls).get()

--- a/kafkistry-service-logic/src/main/kotlin/com/infobip/kafkistry/service/acl/AclsSuggestionService.kt
+++ b/kafkistry-service-logic/src/main/kotlin/com/infobip/kafkistry/service/acl/AclsSuggestionService.kt
@@ -8,6 +8,7 @@ import com.infobip.kafkistry.model.PrincipalId
 import com.infobip.kafkistry.service.*
 import com.infobip.kafkistry.service.acl.AclInspectionResultType.Companion.CLUSTER_DISABLED
 import com.infobip.kafkistry.service.acl.AclInspectionResultType.Companion.CLUSTER_UNREACHABLE
+import com.infobip.kafkistry.service.acl.AclInspectionResultType.Companion.DETACHED
 import com.infobip.kafkistry.service.acl.AclInspectionResultType.Companion.MISSING
 import com.infobip.kafkistry.service.acl.AclInspectionResultType.Companion.NOT_PRESENT_AS_EXPECTED
 import com.infobip.kafkistry.service.acl.AclInspectionResultType.Companion.OK
@@ -96,6 +97,31 @@ class AclsSuggestionService(
                 description = currentPrincipalAcls?.description ?: "",
                 owner = currentPrincipalAcls?.owner ?: "",
                 rules = rules
+        )
+    }
+
+    fun suggestPrincipalAclsWithoutDetachedRules(
+        principal: PrincipalId
+    ): PrincipalAclRules {
+        val currentPrincipalAcls = aclsRegistry.findPrincipalAcls(principal)
+            ?: throw KafkistryIllegalStateException(
+                "Can't remove detached rules of principal '$principal', it does not exist in registry"
+            )
+        val principalAclsInspection = aclsInspector.inspectPrincipalAcls(principal)
+        val detachedRules = principalAclsInspection.clusterInspections
+            .flatMap { clusterInspection ->
+                clusterInspection.statuses
+                    .filter { DETACHED in it.statusTypes }
+                    .map { it.rule }
+            }
+            .toSet()
+        if (detachedRules.isEmpty()) {
+            throw KafkistryIllegalStateException(
+                "Can't remove detached rules of principal '$principal', no detached rules found"
+            )
+        }
+        return currentPrincipalAcls.copy(
+            rules = currentPrincipalAcls.rules.filter { it.toKafkaAclRule(principal) !in detachedRules }
         )
     }
 

--- a/kafkistry-service-logic/src/test/kotlin/com/infobip/kafkistry/service/it/AclsInspectionTest.kt
+++ b/kafkistry-service-logic/src/test/kotlin/com/infobip/kafkistry/service/it/AclsInspectionTest.kt
@@ -114,6 +114,47 @@ class AclsInspectionTest {
     }
 
     @Test
+    fun `test suggest remove detached rules - single detached rule`() {
+        val rule_ok = "User:X * TOPIC:t1 READ ALLOW".parseAcl()
+        val rule_detached = "User:X * TOPIC:t_deleted ALL ALLOW".parseAcl()
+        val principalAcls = PrincipalAclRules(
+            principal = "User:X",
+            description = "test description",
+            owner = "Team_Test",
+            rules = listOf(
+                rule_ok.toAclRule(presenceAll),
+                rule_detached.toAclRule(presenceAll),
+            )
+        )
+        acls.create(principalAcls)
+        clusters.addCluster(cluster1)
+        cluster1.mockClusterStateRules(rule_ok, rule_detached, topics = listOf("t1"))
+        val result = suggestion.suggestPrincipalAclsWithoutDetachedRules("User:X")
+        assertThat(result.principal).isEqualTo("User:X")
+        assertThat(result.description).isEqualTo("test description")
+        assertThat(result.owner).isEqualTo("Team_Test")
+        assertThat(result.rules).hasSize(1)
+        assertThat(result.rules[0].toKafkaAclRule("User:X")).isEqualTo(rule_ok)
+    }
+
+    @Test
+    fun `test suggest remove detached rules - no detached rules throws`() {
+        acls.create(listOf(rule_X_T1).toPrincipalAclRules().first())
+        clusters.addCluster(cluster1)
+        cluster1.mockClusterStateRules(rule_X_T1, topics = listOf("t1"))
+        assertThrows<KafkistryIllegalStateException> {
+            suggestion.suggestPrincipalAclsWithoutDetachedRules("User:X")
+        }
+    }
+
+    @Test
+    fun `test suggest remove detached rules - principal not in registry throws`() {
+        assertThrows<KafkistryIllegalStateException> {
+            suggestion.suggestPrincipalAclsWithoutDetachedRules("User:nonexistent")
+        }
+    }
+
+    @Test
     fun `test missing rule`() {
         acls.create(listOf(rule_X_T1).toPrincipalAclRules().first())
         clusters.addCluster(cluster1)
@@ -510,6 +551,26 @@ class AclsInspectionTest {
                 )
             )
         )
+
+        val suggested_P3_no_detached = suggestion.suggestPrincipalAclsWithoutDetachedRules("User:P3")
+        assertThat(suggested_P3_no_detached).isEqualTo(
+            PrincipalAclRules(
+                principal = "User:P3",
+                description = "for testing",
+                owner = "Team_Test",
+                rules = listOf(
+                    rule_p3_r1.toAclRule(presence("c_1", "c_2")),
+                    rule_p3_r2.toAclRule(presence("c_2", "c_3")),
+                )
+            )
+        )
+
+        assertThrows<KafkistryIllegalStateException> {
+            suggestion.suggestPrincipalAclsWithoutDetachedRules("User:P1")
+        }
+        assertThrows<KafkistryIllegalStateException> {
+            suggestion.suggestPrincipalAclsWithoutDetachedRules("User:P2")
+        }
 
         //P4
         val suggested_P4_acls = suggestion.suggestPrincipalAclsImport("User:P4")

--- a/kafkistry-web-api/src/main/kotlin/com/infobip/kafkistry/api/SuggestionApi.kt
+++ b/kafkistry-web-api/src/main/kotlin/com/infobip/kafkistry/api/SuggestionApi.kt
@@ -147,6 +147,11 @@ class SuggestionApi(
         @RequestParam("principal") principal: PrincipalId
     ): PrincipalAclRules = aclsSuggestionService.suggestPrincipalAclsUpdate(principal)
 
+    @GetMapping("/remove-detached-principal-acls")
+    fun suggestPrincipalAclsWithoutDetachedRules(
+        @RequestParam("principal") principal: PrincipalId
+    ): PrincipalAclRules = aclsSuggestionService.suggestPrincipalAclsWithoutDetachedRules(principal)
+
     @PostMapping("/generate-broker-topic-partition-throttle")
     fun generateBrokerTopicsPartitionsThrottle(
         @RequestBody throttleBrokerTopicPartitions: ThrottleBrokerTopicPartitions

--- a/kafkistry-web/src/main/kotlin/com/infobip/kafkistry/webapp/controller/AclsController.kt
+++ b/kafkistry-web/src/main/kotlin/com/infobip/kafkistry/webapp/controller/AclsController.kt
@@ -23,6 +23,7 @@ import com.infobip.kafkistry.webapp.url.AclsUrls.Companion.ACLS_EDIT_PRINCIPAL_O
 import com.infobip.kafkistry.webapp.url.AclsUrls.Companion.ACLS_IMPORT_PRINCIPAL
 import com.infobip.kafkistry.webapp.url.AclsUrls.Companion.ACLS_PRINCIPAL
 import com.infobip.kafkistry.webapp.url.AclsUrls.Companion.ACLS_PRINCIPAL_HISTORY
+import com.infobip.kafkistry.webapp.url.AclsUrls.Companion.ACLS_REMOVE_DETACHED_RULES
 import com.infobip.kafkistry.webapp.url.AclsUrls.Companion.ACLS_SUGGESTED_EDIT_PRINCIPAL
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.*
@@ -152,6 +153,19 @@ class AclsController(
         val principalAcls = suggestionApi.suggestPrincipalAclsUpdate(principal)
         return ModelAndView("acls/modify/editPrincipalAcls", mapOf(
                 "title" to "Suggested edit to match current state on clusters",
+                "existingValues" to existingValuesApi.all(),
+                "principalSourceType" to "EDIT",
+                "principalAcls" to principalAcls
+        ))
+    }
+
+    @GetMapping(ACLS_REMOVE_DETACHED_RULES)
+    fun showRemoveDetachedRules(
+            @RequestParam("principal") principal: PrincipalId
+    ): ModelAndView {
+        val principalAcls = suggestionApi.suggestPrincipalAclsWithoutDetachedRules(principal)
+        return ModelAndView("acls/modify/editPrincipalAcls", mapOf(
+                "title" to "Edit to remove detached rules",
                 "existingValues" to existingValuesApi.all(),
                 "principalSourceType" to "EDIT",
                 "principalAcls" to principalAcls

--- a/kafkistry-web/src/main/kotlin/com/infobip/kafkistry/webapp/url/AclsUrls.kt
+++ b/kafkistry-web/src/main/kotlin/com/infobip/kafkistry/webapp/url/AclsUrls.kt
@@ -17,6 +17,7 @@ class AclsUrls(base: String) : BaseUrls() {
         const val ACLS_SUGGESTED_EDIT_PRINCIPAL = "/suggested-edit-principal"
         const val ACLS_IMPORT_PRINCIPAL = "/import-principal"
         const val ACLS_DELETE_PRINCIPAL = "/delete-principal"
+        const val ACLS_REMOVE_DETACHED_RULES = "/remove-detached-rules"
         const val ACLS_BULK_CREATE_PRINCIPAL_RULES = "/management/bulk-create-principal-rules"
         const val ACLS_BULK_CREATE_CLUSTER_RULES = "/management/bulk-create-cluster-rules"
         const val ACLS_CREATE_RULES = "/management/create-rules"
@@ -33,6 +34,7 @@ class AclsUrls(base: String) : BaseUrls() {
     private val showEditPrincipal = Url("$base$ACLS_EDIT_PRINCIPAL", listOf("principal"))
     private val showEditPrincipalOnBranch = Url("$base$ACLS_EDIT_PRINCIPAL_ON_BRANCH", listOf("principal", "branch"))
     private val showSuggestedEditPrincipal = Url("$base$ACLS_SUGGESTED_EDIT_PRINCIPAL", listOf("principal"))
+    private val showRemoveDetachedRules = Url("$base$ACLS_REMOVE_DETACHED_RULES", listOf("principal"))
     private val showImportPrincipal = Url("$base$ACLS_IMPORT_PRINCIPAL", listOf("principal"))
     private val showDeletePrincipal = Url("$base$ACLS_DELETE_PRINCIPAL", listOf("principal"))
     private val showBulkCreatePrincipalRules = Url("$base$ACLS_BULK_CREATE_PRINCIPAL_RULES", listOf("principal"))
@@ -72,6 +74,8 @@ class AclsUrls(base: String) : BaseUrls() {
     ) = showEditPrincipalOnBranch.render("principal" to principal, "branch" to branch)
 
     fun showSuggestedEditPrincipal(principal: PrincipalId) = showSuggestedEditPrincipal.render("principal" to principal)
+
+    fun showRemoveDetachedRules(principal: PrincipalId) = showRemoveDetachedRules.render("principal" to principal)
 
     fun showImportPrincipal(principal: PrincipalId) = showImportPrincipal.render("principal" to principal)
 

--- a/kafkistry-web/src/main/resources/ui/acls/principal.ftl
+++ b/kafkistry-web/src/main/resources/ui/acls/principal.ftl
@@ -109,6 +109,19 @@
                         Suggest edit...
                     </a>
                 </#if>
+                <#if existInRegistry>
+                    <#assign hasDetachedRules = false>
+                    <#list principalRuleClusters.status.statusCounts as statusCount>
+                        <#if statusCount.type.name == "DETACHED">
+                            <#assign hasDetachedRules = true>
+                        </#if>
+                    </#list>
+                    <#if hasDetachedRules>
+                        <a href="${appUrl.acls().showRemoveDetachedRules(principal)}" class="btn btn-outline-warning">
+                            Remove detached rules...
+                        </a>
+                    </#if>
+                </#if>
                 <#if existInRegistry && principalActions?seq_contains("CREATE_MISSING_ACLS")>
                     <a href="${appUrl.acls().showBulkCreatePrincipalRules(principal)}" class="btn btn-outline-info">
                         Create all missing ACLs...


### PR DESCRIPTION
When a topic is deleted but ACL rules still reference it, those rules get DETACHED status. Previously, cleaning these up required manually opening "Edit ACLs", finding the detached rules, removing them, and committing. This PR adds a convenient one-click action on the principal page that opens the edit form with detached rules pre-removed.